### PR TITLE
Add project lifecycle enums and state machine

### DIFF
--- a/src/models/enums.py
+++ b/src/models/enums.py
@@ -1,0 +1,23 @@
+from enum import Enum
+
+
+class ProjectStatus(str, Enum):
+    NEW = "NEW"
+    DISCOVERY = "DISCOVERY"
+    PLANNING = "PLANNING"
+    DESIGN = "DESIGN"
+    BUILD = "BUILD"
+    TEST = "TEST"
+    REVIEW = "REVIEW"
+    DEPLOY = "DEPLOY"
+    MONITOR = "MONITOR"
+    DONE = "DONE"
+    TEST_FAIL = "TEST_FAIL"
+    ROLLBACK = "ROLLBACK"
+
+
+class JobState(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    FAILED = "failed"
+    DONE = "done"

--- a/src/models/project.py
+++ b/src/models/project.py
@@ -2,12 +2,14 @@ from sqlmodel import SQLModel, Field, Relationship
 from typing import Optional, List, TYPE_CHECKING
 from datetime import datetime
 
+from .enums import ProjectStatus
+
 if TYPE_CHECKING:
     from .file import File
 
 class Project(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str
-    status: Optional[str] = Field(default="active")
+    status: ProjectStatus = Field(default=ProjectStatus.NEW)
     last_updated: Optional[datetime] = Field(default_factory=datetime.utcnow)
     files: List["File"] = Relationship(back_populates="project")

--- a/src/utils/state_machine.py
+++ b/src/utils/state_machine.py
@@ -1,0 +1,66 @@
+from functools import wraps
+from typing import Iterable
+
+from fastapi import HTTPException
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.models.project import Project
+from src.models.enums import ProjectStatus
+
+ALLOWED_TRANSITIONS = {
+    ProjectStatus.NEW: {ProjectStatus.DISCOVERY},
+    ProjectStatus.DISCOVERY: {ProjectStatus.PLANNING},
+    ProjectStatus.PLANNING: {ProjectStatus.DESIGN},
+    ProjectStatus.DESIGN: {ProjectStatus.BUILD},
+    ProjectStatus.BUILD: {ProjectStatus.TEST},
+    ProjectStatus.TEST: {ProjectStatus.REVIEW, ProjectStatus.TEST_FAIL},
+    ProjectStatus.REVIEW: {ProjectStatus.DEPLOY},
+    ProjectStatus.DEPLOY: {ProjectStatus.MONITOR},
+    ProjectStatus.MONITOR: {ProjectStatus.DONE},
+    ProjectStatus.TEST_FAIL: {ProjectStatus.ROLLBACK, ProjectStatus.TEST},
+    ProjectStatus.ROLLBACK: {ProjectStatus.BUILD},
+}
+
+
+def enforce_state(*, from_: Iterable[ProjectStatus], to: ProjectStatus):
+    """Decorator ensuring a project is in an allowed state before executing."""
+
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            project: Project = kwargs.get("project")
+            session: AsyncSession = kwargs.get("session")
+            if project is None or session is None:
+                raise RuntimeError("project and session must be provided")
+            if project.status not in from_:
+                raise HTTPException(status_code=409, detail="Illegal state transition")
+            result = await func(*args, **kwargs)
+            await advance_state(session, project, to)
+            return result
+
+        return wrapper
+
+    return decorator
+
+
+def _allowed(current: ProjectStatus, target: ProjectStatus) -> bool:
+    return target in ALLOWED_TRANSITIONS.get(current, set())
+
+
+async def advance_state(session: AsyncSession, project: Project, to_status: ProjectStatus) -> Project:
+    if not _allowed(project.status, to_status):
+        raise HTTPException(status_code=409, detail="Illegal state transition")
+    project.status = to_status
+    session.add(project)
+    await session.commit()
+    await session.refresh(project)
+    return project
+
+
+async def get_project(session: AsyncSession, project_id: int) -> Project:
+    result = await session.execute(select(Project).where(Project.id == project_id))
+    project = result.scalar_one_or_none()
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return project

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import os
+import sys
+import asyncio
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
+
+from src.models import project  # ensure models are registered
+from src.db import init_db
+
+# Ensure database tables exist before tests run
+asyncio.run(init_db())

--- a/tests/test_fs_service.py
+++ b/tests/test_fs_service.py
@@ -1,8 +1,11 @@
 import pytest
 from src.services.fs_service import FSService
 
+
 @pytest.mark.asyncio
-async def test_read_file():
+async def test_read_file(tmp_path):
+    file_path = tmp_path / "test.txt"
+    file_path.write_text("hello")
     service = FSService()
-    result = await service.read_file("/tmp/test.txt")
-    assert result is not None
+    result = await service.read_file(str(file_path))
+    assert result == "hello"

--- a/tests/test_index_service.py
+++ b/tests/test_index_service.py
@@ -1,8 +1,16 @@
+import os
 import pytest
 from src.services.index_service import IndexService
 
+
 @pytest.mark.asyncio
-async def test_build_index():
+async def test_build_index(tmp_path):
+    project_dir = "/projects/1"
+    os.makedirs(project_dir, exist_ok=True)
+    (tmp_path / "file.txt").write_text("content")
+    # copy file into expected project path
+    import shutil
+    shutil.copy(tmp_path / "file.txt", os.path.join(project_dir, "file.txt"))
     service = IndexService()
     result = await service.build_index(1)
     assert result is not None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,10 +1,12 @@
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 from src.main import app
+
 
 @pytest.mark.asyncio
 async def test_health():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         response = await ac.get("/api/projects/health")
         assert response.status_code == 200
         assert response.json()["status"] == "ok"

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -1,0 +1,21 @@
+import pytest
+from fastapi import HTTPException
+
+from src.models.project import Project
+from src.models.enums import ProjectStatus
+from src.db import async_session
+from src.utils.state_machine import advance_state
+
+
+@pytest.mark.asyncio
+async def test_state_machine_transitions():
+    async with async_session() as session:
+        project = Project(name="demo")
+        session.add(project)
+        await session.commit()
+        await session.refresh(project)
+        assert project.status == ProjectStatus.NEW
+        await advance_state(session, project, ProjectStatus.DISCOVERY)
+        assert project.status == ProjectStatus.DISCOVERY
+        with pytest.raises(HTTPException):
+            await advance_state(session, project, ProjectStatus.NEW)


### PR DESCRIPTION
## Summary
- define `ProjectStatus` and `JobState` enums
- update `Project` model to use `ProjectStatus`
- add reusable state machine helpers and transition checks
- exercise state transitions and service utilities in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f0e582a888324aa908e00b3fd148d