### PR TITLE
Add project state advancement endpoint

### DIFF
--- a/src/routes/projects.py
+++ b/src/routes/projects.py
@@ -1,11 +1,15 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
 from sqlmodel import select
-from ..db import get_session
-from ..models.project import Project
-from ..services.task_queue import index_task
-from ..services.agent_service import AgentService
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List
+
+from ..db import get_session
+from ..models.enums import ProjectStatus
+from ..models.project import Project
+from ..services.agent_service import AgentService
+from ..services.task_queue import index_task
+from ..utils.state_machine import advance_state, get_project
 
 router = APIRouter()
 
@@ -35,3 +39,18 @@ async def run_agent(project_id: int, payload: dict):
     agent = AgentService()
     result = await agent.run_agent_task(payload)
     return result
+
+
+class StatusUpdate(BaseModel):
+    status: ProjectStatus
+
+
+@router.post("/{project_id}/advance", response_model=Project)
+async def advance_project(
+    project_id: int,
+    update: StatusUpdate,
+    session: AsyncSession = Depends(get_session),
+):
+    project = await get_project(session, project_id)
+    project = await advance_state(session, project, update.status)
+    return project

--- a/tests/test_project_routes.py
+++ b/tests/test_project_routes.py
@@ -1,0 +1,27 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from src.main import app
+
+
+@pytest.mark.asyncio
+async def test_advance_project_endpoint():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        # create a new project
+        create_resp = await ac.post("/api/projects/", json={"name": "demo"})
+        assert create_resp.status_code == 200
+        project_id = create_resp.json()["id"]
+        assert create_resp.json()["status"] == "NEW"
+
+        # advance to DISCOVERY
+        advance_resp = await ac.post(
+            f"/api/projects/{project_id}/advance", json={"status": "DISCOVERY"}
+        )
+        assert advance_resp.status_code == 200
+        assert advance_resp.json()["status"] == "DISCOVERY"
+
+        # invalid transition back to NEW should fail
+        invalid_resp = await ac.post(
+            f"/api/projects/{project_id}/advance", json={"status": "NEW"}
+        )
+        assert invalid_resp.status_code == 409


### PR DESCRIPTION
## Summary
- expose endpoint to advance a project's status through the SDLC lifecycle
- test advancing and rejecting invalid transitions via API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f1583c6a08324aaf414abadbd97c9