### PR TITLE
Add schema contracts and artifacts API

### DIFF
--- a/backend/contracts/events.schema.json
+++ b/backend/contracts/events.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "type": {"type": "string"},
+    "payload": {"type": "object"}
+  },
+  "required": ["type"],
+  "additionalProperties": true
+}

--- a/backend/contracts/plan.schema.json
+++ b/backend/contracts/plan.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "dag": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {"type": "string"},
+              "type": {"type": "string"},
+              "params": {"type": "object"}
+            },
+            "required": ["id", "type", "params"],
+            "additionalProperties": false
+          }
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {"type": "string"},
+              {"type": "string"}
+            ],
+            "minItems": 2,
+            "maxItems": 2
+          }
+        }
+      },
+      "required": ["nodes", "edges"],
+      "additionalProperties": false
+    },
+    "summary": {"type": "string"}
+  },
+  "required": ["dag", "summary"],
+  "additionalProperties": false
+}

--- a/backend/contracts/requirements.schema.json
+++ b/backend/contracts/requirements.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "features": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    }
+  },
+  "required": ["features"],
+  "additionalProperties": false
+}

--- a/backend/contracts/test_report.schema.json
+++ b/backend/contracts/test_report.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "passed": {"type": "boolean"}
+  },
+  "required": ["passed"],
+  "additionalProperties": true
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ asyncpg
 maturin
 greenlet
 alembic
+jsonschema

--- a/src/services/ws_manager.py
+++ b/src/services/ws_manager.py
@@ -1,6 +1,7 @@
 from fastapi import WebSocket
 from typing import List
 import json
+from ..utils.schema import validate_schema
 
 
 class ConnectionManager:
@@ -16,6 +17,7 @@ class ConnectionManager:
             self.active_connections.remove(websocket)
 
     async def broadcast(self, message: dict) -> None:
+        validate_schema(message, "events")
         data = json.dumps(message)
         for connection in list(self.active_connections):
             try:

--- a/src/utils/schema.py
+++ b/src/utils/schema.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+from functools import lru_cache
+from jsonschema import validate as _validate, ValidationError
+from fastapi import HTTPException
+
+CONTRACTS_DIR = Path(__file__).resolve().parents[2] / "backend" / "contracts"
+
+@lru_cache(maxsize=None)
+def _load_schema(name: str):
+    path = CONTRACTS_DIR / f"{name}.schema.json"
+    with path.open() as f:
+        return json.load(f)
+
+
+def validate_schema(data, name: str) -> None:
+    schema = _load_schema(name)
+    try:
+        _validate(instance=data, schema=schema)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.message)

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,0 +1,38 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from src.main import app
+
+
+@pytest.mark.asyncio
+async def test_requirements_validation():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        create = await ac.post("/api/projects/", json={"name": "demo"})
+        project_id = create.json()["id"]
+        resp = await ac.post(
+            f"/api/projects/{project_id}/init", json={"foo": "bar"}
+        )
+        assert resp.status_code == 422
+        assert "features" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_artifact_listing():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        create = await ac.post("/api/projects/", json={"name": "demo"})
+        pid = create.json()["id"]
+        await ac.post(f"/api/projects/{pid}/init", json={"features": ["one"]})
+        await ac.post(f"/api/projects/{pid}/plan")
+        reqs = await ac.get(f"/api/projects/{pid}/artifacts", params={"kind": "requirements"})
+        assert reqs.status_code == 200
+        data = reqs.json()
+        assert len(data) == 1
+        assert data[0]["kind"] == "requirements"
+        assert "features" in data[0]["content"]
+        plan = await ac.get(f"/api/projects/{pid}/artifacts", params={"kind": "plan"})
+        assert plan.status_code == 200
+        pdata = plan.json()
+        assert len(pdata) == 1
+        assert pdata[0]["kind"] == "plan"
+        assert "dag" in pdata[0]["content"]

--- a/tests/test_lifecycle_routes.py
+++ b/tests/test_lifecycle_routes.py
@@ -16,7 +16,7 @@ async def test_lifecycle_basic():
         project_id = create.json()["id"]
 
         init_resp = await ac.post(
-            f"/api/projects/{project_id}/init", json={"req": "value"}
+            f"/api/projects/{project_id}/init", json={"features": ["value"]}
         )
         assert init_resp.status_code == 200
         assert init_resp.json()["status"] == "DISCOVERY"


### PR DESCRIPTION
## Summary
- introduce JSON schemas for requirements, plans, events, and test reports
- validate lifecycle payloads and websocket events against schemas
- add artifact listing and contract retrieval endpoints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f1b1fd70c8324b57daac33b83c0e0