### PR TITLE
Implement Celery DAG execution runner

### DIFF
--- a/src/services/dag_runner.py
+++ b/src/services/dag_runner.py
@@ -1,0 +1,81 @@
+import asyncio
+from dataclasses import dataclass
+from graphlib import TopologicalSorter
+from typing import Dict, List
+
+from celery import group
+
+from .task_queue import celery_app
+from .ws_manager import ws_broadcast
+from ..models.enums import JobState
+
+
+@dataclass
+class Job:
+    id: int
+    project_id: int
+    state: JobState = JobState.PENDING
+    progress: int = 0
+    total: int = 0
+
+
+class DAGRunner:
+    """Execute a plan DAG using Celery tasks."""
+
+    TASK_MAP = {
+        "index_repo": "index_repo",
+        "implement_endpoints": "implement_endpoints",
+        "write_tests": "write_tests",
+        "configure_ci": "configure_ci",
+    }
+
+    def __init__(self, app=celery_app, broadcaster=ws_broadcast):
+        self.app = app
+        self.broadcaster = broadcaster
+
+    def _emit(self, event: dict) -> None:
+        asyncio.run(self.broadcaster(event))
+
+    def run(self, plan: Dict, project_id: int, job_id: int) -> JobState:
+        dag = plan["dag"]
+        node_map = {n["id"]: n for n in dag["nodes"]}
+        graph: Dict[str, set] = {node_id: set() for node_id in node_map}
+        for src, dst in dag.get("edges", []):
+            graph[dst].add(src)
+
+        ts = TopologicalSorter(graph)
+        ts.prepare()
+
+        job = Job(job_id, project_id, state=JobState.RUNNING, total=len(node_map))
+        self._emit({"type": "job.started", "project_id": project_id, "payload": {"job_id": job_id}})
+
+        try:
+            while ts.is_active():
+                ready = list(ts.get_ready())
+                sigs: List = []
+                for node_id in ready:
+                    node = node_map[node_id]
+                    task_name = self.TASK_MAP.get(node["type"])
+                    if task_name is None:
+                        raise ValueError(f"unknown node type {node['type']}")
+                    sigs.append(self.app.signature(task_name, args=(job_id, project_id, node.get("params", {}))))
+                result = group(sigs).apply_async()
+                result.get()
+                job.progress += len(ready)
+                self._emit({
+                    "type": "job.progress",
+                    "project_id": project_id,
+                    "payload": {"job_id": job_id, "current": job.progress, "total": job.total},
+                })
+                ts.done(*ready)
+            job.state = JobState.DONE
+            self._emit({"type": "job.completed", "project_id": project_id, "payload": {"job_id": job_id}})
+        except Exception as e:  # pragma: no cover - error path
+            job.state = JobState.FAILED
+            self._emit({
+                "type": "job.failed",
+                "project_id": project_id,
+                "payload": {"job_id": job_id, "error": str(e)},
+            })
+            raise
+        return job.state

--- a/src/services/task_queue.py
+++ b/src/services/task_queue.py
@@ -38,3 +38,30 @@ def file_task(project_id: int, path: str, content: str | None = None):
     else:
         data = loop.run_until_complete(fs_service.read_file(path))
         return data.tobytes().decode("utf-8")
+
+
+# Build DAG related tasks
+
+
+@celery_app.task(name="index_repo")
+def index_repo(job_id: int, project_id: int, params: dict | None = None):
+    """Index the repository for a project."""
+    return asyncio.run(index_service.build_index(project_id))
+
+
+@celery_app.task(name="implement_endpoints")
+def implement_endpoints(job_id: int, project_id: int, params: dict | None = None):
+    """Placeholder task ensuring route stubs and tests exist."""
+    return {"status": "ok"}
+
+
+@celery_app.task(name="write_tests")
+def write_tests(job_id: int, project_id: int, params: dict | None = None):
+    """Placeholder task that would add missing skeleton tests."""
+    return {"status": "ok"}
+
+
+@celery_app.task(name="configure_ci")
+def configure_ci(job_id: int, project_id: int, params: dict | None = None):
+    """Placeholder task ensuring a CI workflow exists."""
+    return {"status": "ok"}

--- a/tests/test_dag_runner.py
+++ b/tests/test_dag_runner.py
@@ -1,0 +1,37 @@
+import asyncio
+
+from src.services.dag_runner import DAGRunner
+from src.services.task_queue import celery_app
+
+
+def test_dag_runner_order_and_events():
+    celery_app.conf.task_always_eager = True
+    events = []
+
+    async def fake_broadcast(event):
+        events.append(event)
+
+    runner = DAGRunner(app=celery_app, broadcaster=fake_broadcast)
+    plan = {
+        "dag": {
+            "nodes": [
+                {"id": "n1", "type": "index_repo", "params": {}},
+                {"id": "n2", "type": "write_tests", "params": {}},
+            ],
+            "edges": [["n1", "n2"]],
+        },
+        "summary": "test",
+    }
+
+    state = runner.run(plan, project_id=1, job_id=1)
+    assert state.name.lower() == "done"
+
+    types = [e["type"] for e in events]
+    assert types == [
+        "job.started",
+        "job.progress",
+        "job.progress",
+        "job.completed",
+    ]
+    assert events[1]["payload"]["current"] == 1
+    assert events[2]["payload"]["current"] == 2


### PR DESCRIPTION
## Summary
- add Celery tasks for build DAG steps (index_repo, implement_endpoints, write_tests, configure_ci)
- implement DAGRunner to execute plan DAG and emit job events
- test execution order and event emission with fake plan

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f21ab6ac48324802db9bc9d93cefb