### PR TITLE
feat: add incremental file indexing and search

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -2,3 +2,4 @@
 from .project import Project
 from .file import File
 from .artifact import Artifact
+from .file_meta import FileMeta

--- a/src/models/file_meta.py
+++ b/src/models/file_meta.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from typing import Optional, TYPE_CHECKING
+
+from sqlmodel import SQLModel, Field, UniqueConstraint, Relationship
+
+if TYPE_CHECKING:
+    from .project import Project
+
+
+class FileMeta(SQLModel, table=True):
+    """Stored metadata for indexed files."""
+
+    __table_args__ = (UniqueConstraint("project_id", "path"),)
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    project_id: int = Field(foreign_key="project.id")
+    path: str
+    size: int
+    mtime: float
+    hash: str
+    lang: Optional[str] = None
+    symbols_count: int = 0
+    last_indexed_at: Optional[datetime] = None
+
+    project: Optional["Project"] = Relationship(back_populates="file_metas")

--- a/src/models/project.py
+++ b/src/models/project.py
@@ -6,6 +6,7 @@ from .enums import ProjectStatus
 
 if TYPE_CHECKING:
     from .file import File
+    from .file_meta import FileMeta
 
 class Project(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -13,3 +14,4 @@ class Project(SQLModel, table=True):
     status: ProjectStatus = Field(default=ProjectStatus.NEW)
     last_updated: Optional[datetime] = Field(default_factory=datetime.utcnow)
     files: List["File"] = Relationship(back_populates="project")
+    file_metas: List["FileMeta"] = Relationship(back_populates="project")

--- a/src/routes/search.py
+++ b/src/routes/search.py
@@ -1,9 +1,15 @@
 from fastapi import APIRouter
-from ..services.task_queue import search_task
+from typing import Optional
+
+from ..services.index_service import IndexService
 
 router = APIRouter()
+index_service = IndexService()
 
-@router.post("/api/projects/{id}/search")
-async def search_project(id: int, query: str):
-    task = search_task.delay(id, query)
-    return {"task_id": task.id, "status": "search started", "project_id": id, "query": query}
+
+@router.get("/api/projects/{id}/search")
+async def search_project(
+    id: int, q: str, lang: Optional[str] = None, path: Optional[str] = None
+):
+    hits = await index_service.search_index(id, q, lang=lang, path=path)
+    return {"project_id": id, "query": q, "hits": hits}

--- a/src/services/index_service.py
+++ b/src/services/index_service.py
@@ -1,23 +1,108 @@
 import asyncio
-from typing import Any
+import hashlib
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Optional
 
-try:
+from sqlmodel import select, delete
+
+from ..db import async_session
+from ..models import FileMeta
+
+try:  # pragma: no cover - optional dependency
     import indexer_rs
-except Exception:  # pragma: no cover - optional dependency
+except Exception:  # pragma: no cover
     indexer_rs = None
 
-class IndexService:
-    async def build_index(self, project_id: int) -> Any:
-        if indexer_rs is None:
-            return {}
-        loop = asyncio.get_event_loop()
-        path = f"/projects/{project_id}"
-        result = await loop.run_in_executor(None, indexer_rs.build_index, path)
-        return memoryview(result) if hasattr(result, "__buffer__") else result
+ProgressCallback = Callable[[int, str], Any]
 
-    async def search_index(self, query: str) -> Any:
+
+class IndexService:
+    async def build_index(
+        self, project_id: int, progress_cb: Optional[ProgressCallback] = None
+    ) -> dict:
+        """(Re)build index incrementally for a project."""
+
         if indexer_rs is None:
             return {}
+
+        root = Path(f"/projects/{project_id}")
+        if not root.exists():
+            return {}
+
         loop = asyncio.get_event_loop()
-        result = await loop.run_in_executor(None, indexer_rs.search_index, query)
+
+        async with async_session() as session:
+            existing = await session.execute(
+                select(FileMeta).where(FileMeta.project_id == project_id)
+            )
+            meta_map = {m.path: m for m in existing.scalars().all()}
+
+            files_on_disk = [p for p in root.rglob("*") if p.is_file()]
+            changed = []
+            for file_path in files_on_disk:
+                rel = str(file_path.relative_to(root))
+                stat = file_path.stat()
+                meta = meta_map.get(rel)
+                if meta and meta.size == stat.st_size and meta.mtime == stat.st_mtime:
+                    continue
+                content = file_path.read_bytes()
+                file_hash = hashlib.sha256(content).hexdigest()
+                changed.append((file_path, rel, stat, file_hash))
+
+            total = len(changed)
+            for idx, (file_path, rel, stat, file_hash) in enumerate(changed, start=1):
+                await loop.run_in_executor(None, indexer_rs.build_index, str(file_path))
+                meta = meta_map.get(rel)
+                now = datetime.utcnow()
+                if meta:
+                    meta.size = stat.st_size
+                    meta.mtime = stat.st_mtime
+                    meta.hash = file_hash
+                    meta.last_indexed_at = now
+                else:
+                    meta = FileMeta(
+                        project_id=project_id,
+                        path=rel,
+                        size=stat.st_size,
+                        mtime=stat.st_mtime,
+                        hash=file_hash,
+                        lang=file_path.suffix.lstrip(".") or None,
+                        symbols_count=0,
+                        last_indexed_at=now,
+                    )
+                session.add(meta)
+                await session.commit()
+                if progress_cb:
+                    percent = int(idx * 100 / total) if total else 100
+                    if asyncio.iscoroutinefunction(progress_cb):
+                        await progress_cb(percent, rel)
+                    else:  # pragma: no cover - sync callbacks
+                        progress_cb(percent, rel)
+
+            current_paths = {str(p.relative_to(root)) for p in files_on_disk}
+            stale = set(meta_map.keys()) - current_paths
+            for rel in stale:
+                await session.execute(
+                    delete(FileMeta).where(
+                        FileMeta.project_id == project_id, FileMeta.path == rel
+                    )
+                )
+            if stale:
+                await session.commit()
+
+        return {"indexed": total}
+
+    async def search_index(
+        self, project_id: int, query: str, lang: str | None = None, path: str | None = None
+    ) -> Any:
+        if indexer_rs is None:
+            return []
+        loop = asyncio.get_event_loop()
+        search_q = query
+        if lang:
+            search_q += f" lang:{lang}"
+        if path:
+            search_q += f" path:{path}"
+        result = await loop.run_in_executor(None, indexer_rs.search_index, search_q)
         return memoryview(result) if hasattr(result, "__buffer__") else result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ if ROOT not in sys.path:
 
 os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
 
-from src.models import project  # ensure models are registered
+from src.models import project, file_meta  # ensure models are registered
 from src.db import init_db
 
 # Ensure database tables exist before tests run

--- a/tests/test_index_service.py
+++ b/tests/test_index_service.py
@@ -1,16 +1,30 @@
-import os
+from pathlib import Path
+
 import pytest
+
 from src.services.index_service import IndexService
 
 
 @pytest.mark.asyncio
-async def test_build_index(tmp_path):
-    project_dir = "/projects/1"
-    os.makedirs(project_dir, exist_ok=True)
-    (tmp_path / "file.txt").write_text("content")
-    # copy file into expected project path
-    import shutil
-    shutil.copy(tmp_path / "file.txt", os.path.join(project_dir, "file.txt"))
+async def test_incremental_indexing(monkeypatch):
+    project_dir = Path("/projects/1")
+    project_dir.mkdir(parents=True, exist_ok=True)
+    file_path = project_dir / "file.txt"
+    file_path.write_text("content")
+
+    calls = []
+
+    class DummyIndexer:
+        def build_index(self, path: str):  # pragma: no cover - stub
+            calls.append(path)
+
+    monkeypatch.setattr(
+        "src.services.index_service.indexer_rs", DummyIndexer()
+    )
+
     service = IndexService()
-    result = await service.build_index(1)
-    assert result is not None
+    await service.build_index(1)
+    assert len(calls) == 1
+
+    await service.build_index(1)
+    assert len(calls) == 1  # unchanged file skipped

--- a/tests/test_search_route.py
+++ b/tests/test_search_route.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+from src.main import app
+
+
+def test_search_endpoint(monkeypatch):
+    client = TestClient(app)
+
+    class DummyIndexer:
+        def search_index(self, query: str):  # pragma: no cover - stub
+            return ["result"]
+
+    monkeypatch.setattr(
+        "src.services.index_service.indexer_rs", DummyIndexer()
+    )
+
+    response = client.get("/api/projects/1/search", params={"q": "test"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["project_id"] == 1
+    assert data["query"] == "test"
+    assert data["hits"] == ["result"]


### PR DESCRIPTION
## Summary
- add FileMeta table for tracking file hashes and index timestamps
- incrementally index changed files with progress events
- expose GET /api/projects/{id}/search endpoint backed by Rust indexer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f26f8e0b483249e11e168eed25f7c