### PR TITLE
Add agent contracts and registry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ maturin
 greenlet
 alembic
 jsonschema
+aiosqlite

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,35 @@
+from .contracts import (
+    PlannerInput,
+    PlannerOutput,
+    DesignerInput,
+    DesignerOutput,
+    ImplementerInput,
+    ImplementerOutput,
+    TesterInput,
+    TesterOutput,
+    ReviewerInput,
+    ReviewerOutput,
+    DeployerInput,
+    DeployerOutput,
+    CriticInput,
+    CriticOutput,
+)
+from .registry import agent_registry
+
+__all__ = [
+    "PlannerInput",
+    "PlannerOutput",
+    "DesignerInput",
+    "DesignerOutput",
+    "ImplementerInput",
+    "ImplementerOutput",
+    "TesterInput",
+    "TesterOutput",
+    "ReviewerInput",
+    "ReviewerOutput",
+    "DeployerInput",
+    "DeployerOutput",
+    "CriticInput",
+    "CriticOutput",
+    "agent_registry",
+]

--- a/src/agents/contracts.py
+++ b/src/agents/contracts.py
@@ -1,0 +1,64 @@
+from typing import Any, Dict, List
+from pydantic import BaseModel
+
+
+class PlannerInput(BaseModel):
+    requirements: List[str]
+
+
+class PlannerOutput(BaseModel):
+    dag: Dict[str, Any]
+    acceptance: List[str]
+
+
+class DesignerInput(BaseModel):
+    plan: PlannerOutput
+
+
+class DesignerOutput(BaseModel):
+    openapi: Dict[str, Any]
+    adrs: List[str]
+
+
+class ImplementerInput(BaseModel):
+    design: DesignerOutput
+
+
+class ImplementerOutput(BaseModel):
+    patches: List[str]
+
+
+class TesterInput(BaseModel):
+    patch: ImplementerOutput
+
+
+class TesterOutput(BaseModel):
+    report: str
+
+
+class ReviewerInput(BaseModel):
+    report: TesterOutput
+    diff: ImplementerOutput
+
+
+class ReviewerOutput(BaseModel):
+    approved: bool
+    comments: List[str]
+
+
+class DeployerInput(BaseModel):
+    build: ImplementerOutput
+
+
+class DeployerOutput(BaseModel):
+    image_refs: List[str]
+    runbook: str
+
+
+class CriticInput(BaseModel):
+    artifact: str
+
+
+class CriticOutput(BaseModel):
+    findings: List[str]
+    suggestions: List[str]

--- a/src/agents/registry.py
+++ b/src/agents/registry.py
@@ -1,0 +1,85 @@
+from typing import Awaitable, Callable, Dict
+
+from pydantic import BaseModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from ..models.artifact import Artifact
+from .contracts import (
+    PlannerInput,
+    PlannerOutput,
+    DesignerInput,
+    DesignerOutput,
+    ImplementerInput,
+    ImplementerOutput,
+    TesterInput,
+    TesterOutput,
+    ReviewerInput,
+    ReviewerOutput,
+    DeployerInput,
+    DeployerOutput,
+    CriticInput,
+    CriticOutput,
+)
+
+AgentFunc = Callable[[AsyncSession, int, BaseModel], Awaitable[BaseModel]]
+
+
+async def _persist(session: AsyncSession, project_id: int, kind: str, content: str) -> Artifact:
+    artifact = Artifact(project_id=project_id, kind=kind, content=content)
+    session.add(artifact)
+    await session.commit()
+    await session.refresh(artifact)
+    return artifact
+
+
+async def planner(session: AsyncSession, project_id: int, inp: PlannerInput) -> PlannerOutput:
+    output = PlannerOutput(dag={"nodes": [], "edges": []}, acceptance=[])
+    await _persist(session, project_id, "plan", output.model_dump_json())
+    return output
+
+
+async def designer(session: AsyncSession, project_id: int, inp: DesignerInput) -> DesignerOutput:
+    output = DesignerOutput(openapi={}, adrs=[])
+    await _persist(session, project_id, "design", output.model_dump_json())
+    return output
+
+
+async def implementer(session: AsyncSession, project_id: int, inp: ImplementerInput) -> ImplementerOutput:
+    output = ImplementerOutput(patches=[])
+    await _persist(session, project_id, "patches", output.model_dump_json())
+    return output
+
+
+async def tester(session: AsyncSession, project_id: int, inp: TesterInput) -> TesterOutput:
+    output = TesterOutput(report="")
+    await _persist(session, project_id, "test-report", output.model_dump_json())
+    return output
+
+
+async def reviewer(session: AsyncSession, project_id: int, inp: ReviewerInput) -> ReviewerOutput:
+    output = ReviewerOutput(approved=True, comments=[])
+    await _persist(session, project_id, "review", output.model_dump_json())
+    return output
+
+
+async def deployer(session: AsyncSession, project_id: int, inp: DeployerInput) -> DeployerOutput:
+    output = DeployerOutput(image_refs=[], runbook="")
+    await _persist(session, project_id, "deployment", output.model_dump_json())
+    return output
+
+
+async def critic(session: AsyncSession, project_id: int, inp: CriticInput) -> CriticOutput:
+    output = CriticOutput(findings=[], suggestions=[])
+    await _persist(session, project_id, "critique", output.model_dump_json())
+    return output
+
+
+agent_registry: Dict[str, Callable[..., Awaitable[BaseModel]]] = {
+    "planner": planner,
+    "designer": designer,
+    "implementer": implementer,
+    "tester": tester,
+    "reviewer": reviewer,
+    "deployer": deployer,
+    "critic": critic,
+}

--- a/tests/test_agent_contracts.py
+++ b/tests/test_agent_contracts.py
@@ -1,0 +1,71 @@
+import pytest
+from pydantic import BaseModel
+from typing import Type
+
+from src.agents import (
+    PlannerInput,
+    PlannerOutput,
+    DesignerInput,
+    DesignerOutput,
+    ImplementerInput,
+    ImplementerOutput,
+    TesterInput,
+    TesterOutput,
+    ReviewerInput,
+    ReviewerOutput,
+    DeployerInput,
+    DeployerOutput,
+    CriticInput,
+    CriticOutput,
+    agent_registry,
+)
+
+
+@pytest.mark.parametrize(
+    "model,data",
+    [
+        (PlannerInput, {"requirements": ["feature"]}),
+        (
+            PlannerOutput,
+            {"dag": {"nodes": [], "edges": []}, "acceptance": ["done"]},
+        ),
+        (DesignerInput, {"plan": PlannerOutput(dag={}, acceptance=[])}),
+        (DesignerOutput, {"openapi": {}, "adrs": []}),
+        (ImplementerInput, {"design": DesignerOutput(openapi={}, adrs=[])}),
+        (ImplementerOutput, {"patches": []}),
+        (TesterInput, {"patch": ImplementerOutput(patches=[])}),
+        (TesterOutput, {"report": "ok"}),
+        (
+            ReviewerInput,
+            {
+                "report": TesterOutput(report="ok"),
+                "diff": ImplementerOutput(patches=[]),
+            },
+        ),
+        (ReviewerOutput, {"approved": True, "comments": []}),
+        (DeployerInput, {"build": ImplementerOutput(patches=[])}),
+        (DeployerOutput, {"image_refs": [], "runbook": ""}),
+        (CriticInput, {"artifact": ""}),
+        (CriticOutput, {"findings": [], "suggestions": []}),
+    ],
+)
+def test_serialization_round_trip(model: Type[BaseModel], data: dict):
+    obj = model(**data)
+    dumped = obj.model_dump_json()
+    loaded = model.model_validate_json(dumped)
+    assert obj == loaded
+
+
+def test_registry_roles():
+    roles = [
+        "planner",
+        "designer",
+        "implementer",
+        "tester",
+        "reviewer",
+        "deployer",
+        "critic",
+    ]
+    for role in roles:
+        assert role in agent_registry
+        assert callable(agent_registry[role])


### PR DESCRIPTION
## Summary
- define pydantic contracts for planner, designer, implementer, tester, reviewer, deployer and critic agents
- add agent registry that saves each agent's output as an Artifact
- cover serialization round-trips and registry mapping in tests

## Testing
- `pytest tests/test_agent_contracts.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f2af6c3a08324824512483fe0c560