### PR TITLE
Add multi-provider LLM router with fallback and budgets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ greenlet
 alembic
 jsonschema
 aiosqlite
+PyYAML
+litellm

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -15,6 +15,7 @@ from .contracts import (
     CriticOutput,
 )
 from .registry import agent_registry
+from .router import ModelRouter
 
 __all__ = [
     "PlannerInput",
@@ -32,4 +33,5 @@ __all__ = [
     "CriticInput",
     "CriticOutput",
     "agent_registry",
+    "ModelRouter",
 ]

--- a/src/agents/config/models.yaml
+++ b/src/agents/config/models.yaml
@@ -1,0 +1,77 @@
+planner:
+  primary:
+    provider: openai
+    model: gpt-4o
+    params: {}
+    budgets:
+      max_tokens: 1000
+      max_latency: 30
+    cost_per_token: 0.00001
+  fallbacks:
+    - provider: anthropic
+      model: claude-3-opus
+      params: {}
+      budgets:
+        max_tokens: 1000
+        max_latency: 30
+      cost_per_token: 0.00002
+
+# Strong model also for designer
+# Fallback to same as planner
+
+designer:
+  primary:
+    provider: openai
+    model: gpt-4o
+    params: {}
+    budgets:
+      max_tokens: 1000
+      max_latency: 30
+    cost_per_token: 0.00001
+  fallbacks:
+    - provider: anthropic
+      model: claude-3-opus
+      params: {}
+      budgets:
+        max_tokens: 1000
+        max_latency: 30
+      cost_per_token: 0.00002
+
+# Smaller/faster for implementer
+implementer:
+  primary:
+    provider: openai
+    model: gpt-4o-mini
+    params: {}
+    budgets:
+      max_tokens: 500
+      max_latency: 15
+    cost_per_token: 0.000005
+  fallbacks:
+    - provider: groq
+      model: llama3-8b
+      params: {}
+      budgets:
+        max_tokens: 500
+        max_latency: 15
+      cost_per_token: 0.000003
+
+# Smaller/faster for deployer
+
+deployer:
+  primary:
+    provider: google
+    model: gemini-pro
+    params: {}
+    budgets:
+      max_tokens: 500
+      max_latency: 15
+    cost_per_token: 0.000004
+  fallbacks:
+    - provider: openrouter
+      model: gpt-4o-mini
+      params: {}
+      budgets:
+        max_tokens: 500
+        max_latency: 15
+      cost_per_token: 0.000005

--- a/src/agents/router.py
+++ b/src/agents/router.py
@@ -1,0 +1,80 @@
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+@dataclass
+class ModelSpec:
+    provider: str
+    model: str
+    params: Dict[str, Any] = field(default_factory=dict)
+    budgets: Dict[str, Any] = field(default_factory=dict)
+    cost_per_token: float = 0.0
+
+
+class ModelRouter:
+    """Route LLM requests across providers with fallback and budgeting."""
+
+    def __init__(self, config_path: Optional[str] = None):
+        if config_path is None:
+            config_path = Path(__file__).with_name("config") / "models.yaml"
+        with open(config_path, "r", encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+        self.policies: Dict[str, Dict[str, List[ModelSpec] | ModelSpec]] = {}
+        for role, cfg in raw.items():
+            primary = ModelSpec(**cfg["primary"])
+            fallbacks = [ModelSpec(**fb) for fb in cfg.get("fallbacks", [])]
+            self.policies[role] = {"primary": primary, "fallbacks": fallbacks}
+
+    async def chat(self, role: str, messages: List[Dict[str, str]], job: Optional[Any] = None) -> str:
+        if role not in self.policies:
+            raise KeyError(f"unknown role {role}")
+        policy = self.policies[role]
+        models: List[ModelSpec] = [policy["primary"]] + policy.get("fallbacks", [])
+        last_error: Optional[Exception] = None
+        for spec in models:
+            try:
+                start = time.perf_counter()
+                data = await self._invoke(spec.provider, spec.model, messages, spec.params)
+                latency = time.perf_counter() - start
+                tokens = data.get("usage", {}).get("total_tokens", 0)
+                max_tokens = spec.budgets.get("max_tokens")
+                if max_tokens is not None and tokens > max_tokens:
+                    raise ValueError("token budget exceeded")
+                max_latency = spec.budgets.get("max_latency")
+                if max_latency is not None and latency > max_latency:
+                    raise TimeoutError("latency budget exceeded")
+                cost = tokens * spec.cost_per_token
+                record = {
+                    "provider": spec.provider,
+                    "model": spec.model,
+                    "tokens": tokens,
+                    "latency": latency,
+                    "cost": cost,
+                }
+                if job is not None and hasattr(job, "outputs"):
+                    job.outputs.append(record)
+                return data["choices"][0]["message"]["content"]
+            except Exception as e:  # pragma: no cover - fallback path tested separately
+                last_error = e
+                continue
+        raise last_error or RuntimeError("all providers failed")
+
+    async def _invoke(
+        self, provider: str, model: str, messages: List[Dict[str, str]], params: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Call out to a provider via LiteLLM."""
+        import litellm
+
+        kwargs = {"model": model, "messages": messages, **params}
+        env_key = f"{provider.upper()}_API_KEY"
+        api_key = os.getenv(env_key)
+        if api_key:
+            kwargs["api_key"] = api_key
+        return await litellm.acompletion(**kwargs)
+
+
+__all__ = ["ModelRouter"]

--- a/src/services/dag_runner.py
+++ b/src/services/dag_runner.py
@@ -1,7 +1,7 @@
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from graphlib import TopologicalSorter
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from celery import group
 
@@ -17,6 +17,7 @@ class Job:
     state: JobState = JobState.PENDING
     progress: int = 0
     total: int = 0
+    outputs: List[Dict[str, Any]] = field(default_factory=list)
 
 
 class DAGRunner:

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,48 @@
+import asyncio
+import pytest
+
+from src.agents.router import ModelRouter
+from src.services.dag_runner import Job
+
+
+def test_fallback_on_error(monkeypatch):
+    router = ModelRouter()
+
+    async def fake_invoke(self, provider, model, messages, params):
+        if provider == "openai":
+            raise RuntimeError("boom")
+        return {
+            "choices": [{"message": {"content": "ok"}}],
+            "usage": {"total_tokens": 5},
+        }
+
+    monkeypatch.setattr(ModelRouter, "_invoke", fake_invoke, raising=False)
+    job = Job(1, 1)
+    result = asyncio.run(router.chat("planner", [{"role": "user", "content": "hi"}], job))
+    assert result == "ok"
+    assert job.outputs[0]["provider"] == "anthropic"
+    assert job.outputs[0]["tokens"] == 5
+    assert job.outputs[0]["cost"] > 0
+
+
+def test_fallback_on_budget(monkeypatch):
+    router = ModelRouter()
+
+    async def fake_invoke(self, provider, model, messages, params):
+        if provider == "openai":
+            return {
+                "choices": [{"message": {"content": "too many"}}],
+                "usage": {"total_tokens": 2000},
+            }
+        return {
+            "choices": [{"message": {"content": "ok"}}],
+            "usage": {"total_tokens": 10},
+        }
+
+    monkeypatch.setattr(ModelRouter, "_invoke", fake_invoke, raising=False)
+    job = Job(2, 1)
+    result = asyncio.run(router.chat("planner", [{"role": "user", "content": "hi"}], job))
+    assert result == "ok"
+    assert job.outputs[0]["provider"] == "anthropic"
+    assert job.outputs[0]["tokens"] == 10
+    assert job.outputs[0]["cost"] > 0


### PR DESCRIPTION
## Summary
- add YAML config mapping agent roles to primary and fallback models
- implement ModelRouter that loads config, enforces token/latency budgets, and records provider metrics
- extend Job model with outputs to capture LLM call metadata
- cover routing and fallback scenarios with new unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f2c78a1408324890fb7aecbaa7a24